### PR TITLE
Fix and adapt optional requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(name='feedinlib',
       version='0.0.12',
-      description='Creating time series from pv or wind power plants.',
+      description='Creating time series of pv or wind power plants.',
       url='http://github.com/oemof/feedinlib',
       author='oemof developing group',
       author_email='birgit.schachler@rl-institut.de',
@@ -18,6 +18,8 @@ setup(name='feedinlib',
       zip_safe=False,
       install_requires=['numpy >= 1.7.0',
                         'pandas >= 0.13.1',
-                        'pvlib >= 0.4.0',
-                        'windpowerlib == 0.0.4',
-                        'requests'])
+                        'scipy'],
+      extras_require={
+          'PVlib': ['pvlib >= 0.5.0'],
+          'Windpowerlib': ['windpowerlib >= 0.1.0'],
+      })


### PR DESCRIPTION
When I tried to install the feedinlib it did not work because of the ["optional"] setting for the pvlib. I changed pvlib and windpowerlib to be in "extras_require". See [this setup.py of another project](https://github.com/open-fred/feedin_germany/blob/master/setup.py) for how to use the extras_require packages.