### PR TITLE
Add factor to allow scaling, scaling is not possible at the moment

### DIFF
--- a/src/feedinlib/powerplants.py
+++ b/src/feedinlib/powerplants.py
@@ -371,7 +371,7 @@ class WindPowerPlant(Base):
         if scaling:
             feedin_scaling = {
                 "nominal_power": lambda feedin: feedin
-                / float(self.nominal_power)
+                / float(self.nominal_power) * kwargs.get("scaling_value", 1)
             }
             return feedin_scaling[scaling](feedin)
         return feedin


### PR DESCRIPTION
In the `simple_feedin.py` example I found the following code:

```python
feedin_scaled = e82.feedin(
    weather=weather_df_wind,
    location=(52, 13),
    scaling="nominal_power",
    scaling_value=5e6,
    )
```

In my opinion it does not work without the changes of this PR.