### PR TITLE
Revise weather df from era5

### DIFF
--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.7, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ docs/temp/*
 
 # Mypy Cache
 .mypy_cache/
+
+# downloaded test data
+tests/test_data/*

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -79,7 +78,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "cdsapi >= 0.1.4",
         "geopandas",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,9 @@ setup(
             "punch.py",
             "pytest",
             "sphinx_rtd_theme",
-            "open_FRED-cli"
+            "open_FRED-cli",
+            "shapely",
+            "requests"
         ],
         "data-sources": [
             "open_FRED-cli",

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -406,6 +406,9 @@ def weather_df_from_era5(
             "It must be either 'pvlib' or 'windpowerlib'."
         )
 
+    if len(df) == 0:
+        return pd.DataFrame()
+
     # drop latitude and longitude from index in case a single location
     # is given in parameter `area`
     if area is not None and isinstance(area, list):

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -351,7 +351,12 @@ def select_geometry(ds, area):
 
 
 def weather_df_from_era5(
-    era5_netcdf_filename, lib, start=None, end=None, area=None
+    era5_netcdf_filename,
+    lib,
+    start=None,
+    end=None,
+    area=None,
+    drop_coord_levels=False,
 ):
     """
     Gets ERA5 weather data from netcdf file and converts it to a pandas
@@ -376,6 +381,9 @@ def weather_df_from_era5(
         If you want data for an area you can provide a shape of this area or
         specify a rectangular area giving a list of the
         form [(lon west, lon east), (lat south, lat north)].
+    drop_coord_levels : bool
+        Decide whether the index levels of the coordinates will be dropped. A
+        ValueError is raised if there are more than one coordinates.
 
     Returns
     -------
@@ -411,8 +419,13 @@ def weather_df_from_era5(
 
     # drop latitude and longitude from index in case a single location
     # is given in parameter `area`
-    if area is not None and isinstance(area, list):
-        if np.size(area[0]) == 1 and np.size(area[1]) == 1:
+    if drop_coord_levels is True:
+        if len(df.groupby(level=[1, 2]).count()) > 1:
+            msg = ("You cannot drop the coordinate levels if there are more "
+                   "than one point. You will get duplicate entries in the "
+                   "index.")
+            raise ValueError(msg)
+        else:
             df.index = df.index.droplevel(level=[1, 2])
 
     if start is None:

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -343,11 +343,9 @@ def select_geometry(ds, area):
             np.logical_and((ds.longitude == lon), (ds.latitude == lat))
         )
     # bind all conditions from the list
-    if len(logical_list[:2]) > 1:
-        cond = np.logical_or(*logical_list[:2])
-    else:
-        cond = logical_list[:2]
-    for new_cond in logical_list[2:]:
+    cond = logical_list[0]
+
+    for new_cond in logical_list[1:]:
         cond = np.logical_or(cond, new_cond)
 
     # apply the condition to where

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -429,7 +429,10 @@ def weather_df_from_era5(
                    "index.")
             raise ValueError(msg)
         else:
+            lat = round(df.index.get_level_values(1)[0], 2)
+            lon = round(df.index.get_level_values(2)[0], 2)
             df.index = df.index.droplevel(level=[1, 2])
+            df.index.name = (lat, lon)
 
     if start is None:
         start = df.index[0]

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -271,6 +271,21 @@ def select_area(ds, lon, lat, g_step=0.25):
     return answer
 
 
+def extract_coordinates_from_era5(era5_netcdf_filename):
+    """
+    Extract all coordinates from a er5 netCDf-file and return them as a
+    geopandas.Series
+    """
+    ds = xr.open_dataset(era5_netcdf_filename)
+
+    # Extract all points from the netCDF-file:
+    points = []
+    for x in ds.longitude:
+        for y in ds.latitude:
+            points.append(Point(x, y))
+    return gpd.GeoSeries(points)
+
+
 def select_geometry(ds, area):
     """
     Select data for given geometry from dataset.

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -322,7 +322,12 @@ def select_geometry(ds, area):
     crs = {"init": "epsg:4326"}
     geo_df = gpd.GeoDataFrame(df, crs=crs, geometry=geometry)
 
-    inside_points = geo_df.within(area)
+    if isinstance(area, Point):
+        d = geo_df.apply(lambda row: area.distance(row.geometry), axis=1)
+        inside_points = (d == d.min())
+    else:
+        inside_points = geo_df.within(area)
+
     # if no points lie within area, return None
     if not inside_points.any():
         return None
@@ -337,7 +342,6 @@ def select_geometry(ds, area):
         logical_list.append(
             np.logical_and((ds.longitude == lon), (ds.latitude == lat))
         )
-
     # bind all conditions from the list
     if len(logical_list[:2]) > 1:
         cond = np.logical_or(*logical_list[:2])

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -117,9 +117,9 @@ def format_windpowerlib(ds):
     # the time stamp given by ERA5 for mean values (probably) corresponds to
     # the end of the valid time interval; the following sets the time stamp
     # to the middle of the valid time interval
-    df['time'] = df.time - pd.Timedelta(minutes=60)
+    df["time"] = df.time - pd.Timedelta(minutes=60)
 
-    df.set_index(['time', 'latitude', 'longitude'], inplace=True)
+    df.set_index(["time", "latitude", "longitude"], inplace=True)
     df.sort_index(inplace=True)
     df = df.tz_localize("UTC", level=0)
 
@@ -202,9 +202,9 @@ def format_pvlib(ds):
     # the time stamp given by ERA5 for mean values (probably) corresponds to
     # the end of the valid time interval; the following sets the time stamp
     # to the middle of the valid time interval
-    df['time'] = df.time - pd.Timedelta(minutes=30)
+    df["time"] = df.time - pd.Timedelta(minutes=30)
 
-    df.set_index(['time', 'latitude', 'longitude'], inplace=True)
+    df.set_index(["time", "latitude", "longitude"], inplace=True)
     df.sort_index(inplace=True)
     df = df.tz_localize("UTC", level=0)
 
@@ -373,7 +373,7 @@ def weather_df_from_era5(
     end : None or anything `pandas.to_datetime` can convert to a timestamp
         Get weather data upto this date. Defaults to None in which
         case the end date is set to the last time step in the dataset.
-    area : shapely compatible geometry object (i.e. Polygon,  Multipolygon, etc...) or list(float) or list(tuple)
+    area : shapely.geometry object (i.e. Polygon,  Multipolygon, etc...) or list(float) or list(tuple)
         Area specifies for which geographic area to return weather data. Area
         can either be a single location or an area.
         In case you want data for a single location provide a list in the
@@ -381,6 +381,9 @@ def weather_df_from_era5(
         If you want data for an area you can provide a shape of this area or
         specify a rectangular area giving a list of the
         form [(lon west, lon east), (lat south, lat north)].
+    lib : str
+        Format the weather data for a specific library. Possible values are
+        `windpowerlib` and `pvlib`.
     drop_coord_levels : bool
         Decide whether the index levels of the coordinates will be dropped. A
         ValueError is raised if there are more than one coordinates.

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -339,7 +339,10 @@ def select_geometry(ds, area):
         )
 
     # bind all conditions from the list
-    cond = np.logical_or(*logical_list[:2])
+    if len(logical_list[:2]) > 1:
+        cond = np.logical_or(*logical_list[:2])
+    else:
+        cond = logical_list[:2]
     for new_cond in logical_list[2:]:
         cond = np.logical_or(cond, new_cond)
 

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -1,0 +1,201 @@
+import json
+import os
+
+import pandas as pd
+import pytest
+import requests
+from shapely.geometry import GeometryCollection
+from shapely.geometry import Polygon
+from shapely.geometry import shape
+
+from feedinlib.era5 import weather_df_from_era5
+from feedinlib.era5 import extract_coordinates_from_era5
+
+
+class TestEra5MultiLocation:
+    @classmethod
+    def setup_class(cls):
+        data_path = os.path.join(os.path.dirname(__file__), "test_data")
+        os.makedirs(data_path, exist_ok=True)
+
+        # Download example files if they do not exist.
+        files = {
+            "zncmb": "era5_feedinlib_berlin_2017.nc",
+            "txmze": "berlin_shape.geojson",
+            "96qyt": "germany_simple.geojson",
+        }
+
+        files = {k: os.path.join(data_path, v) for k, v in files.items()}
+
+        for key, file in files.items():
+            if not os.path.isfile(file):
+                req = requests.get("https://osf.io/{0}/download".format(key))
+                with open(file, "wb") as fout:
+                    fout.write(req.content)
+
+        cls.era5_netcdf_file = files["zncmb"]
+        cls.geo_germany = files["96qyt"]
+        cls.geo_berlin = files["txmze"]
+
+    def test_big_bounding_box(self):
+        area = [(13.2, 13.4), (52.4, 52.8)]
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file, lib="pvlib", area=area
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 2
+        coords_round = [round(p, 2) for c in coords for p in c]
+        assert coords_round == [52.55, 13.35, 52.8, 13.35]
+
+    def test_empty_bounding_box(self):
+        area = [(17.2, 17.4), (53.4, 53.8)]
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file, lib="pvlib", area=area
+        )
+        assert len(weather) == 0
+        assert isinstance(weather, pd.DataFrame)
+
+    def test_small_bounding_box(self):
+        area = [(13.2, 13.4), (52.4, 52.6)]
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file, lib="pvlib", area=area
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 1
+        coords_round = [round(p, 2) for c in coords for p in c]
+        assert coords_round == [52.55, 13.35]
+
+    def test_big_polygon(self):
+        lat_point_list = [52.1, 52.1, 52.65]
+        lon_point_list = [13.0, 13.4, 13.4]
+        area = Polygon(zip(lon_point_list, lat_point_list))
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 2
+        coords_round = [round(p, 2) for c in coords for p in c]
+        assert coords_round == [52.3, 13.35, 52.55, 13.35]
+
+    def test_empty_polygon(self):
+        lat_point_list = [53.1, 53.1, 53.65]
+        lon_point_list = [15.0, 15.4, 15.4]
+        area = Polygon(zip(lon_point_list, lat_point_list))
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        assert len(weather) == 0
+        assert isinstance(weather, pd.DataFrame)
+
+    def test_small_polygon(self):
+        lat_point_list = [52.35, 52.35, 52.65]
+        lon_point_list = [13.0, 13.4, 13.4]
+        area = Polygon(zip(lon_point_list, lat_point_list))
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 1
+        coords_round = [round(p, 2) for c in coords for p in c]
+        assert coords_round == [52.55, 13.35]
+
+    def test_no_area(self):
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file, lib="windpowerlib"
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 9
+        assert len(weather.index) == 78840
+
+    def test_time_filter(self):
+        start = "2017-07-01"
+        end = "2017-07-02"
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            start=start,
+            end=end,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 9
+        assert len(weather.index) / len(coords) == 25
+
+    def test_with_germany_polygon(self):
+        with open(self.geo_germany) as f:
+            features = json.load(f)["features"]
+        area = GeometryCollection(
+            [shape(feature["geometry"]).buffer(0) for feature in features]
+        )
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 9
+
+    def test_with_berlin_polygon(self):
+        with open(self.geo_berlin) as f:
+            features = json.load(f)["features"]
+        area = GeometryCollection(
+            [shape(feature["geometry"]).buffer(0) for feature in features]
+        )
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 1
+        coords_round = [round(p, 2) for c in coords for p in c]
+        assert coords_round == [52.55, 13.35]
+
+    def test_with_single_point(self):
+        points = extract_coordinates_from_era5(self.era5_netcdf_file)
+        area = points[0]
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+        )
+        coords = weather.groupby(level=[1, 2]).mean().index
+        assert len(coords) == 1
+
+    def test_level_drop_for_multi_coordinates(self):
+        msg = "You cannot drop the coordinate levels if there are more than"
+        with pytest.raises(ValueError, match=msg):
+            weather_df_from_era5(
+                era5_netcdf_filename=self.era5_netcdf_file,
+                lib="windpowerlib",
+                drop_coord_levels=True,
+            )
+
+    def test_keep_level_for_single_coordinate(self):
+        lat_point_list = [52.35, 52.35, 52.65]
+        lon_point_list = [13.0, 13.4, 13.4]
+        area = Polygon(zip(lon_point_list, lat_point_list))
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+            drop_coord_levels=False,
+        )
+        assert isinstance(weather.index, pd.MultiIndex)
+
+    def test_drop_level_for_single_coordinate(self):
+        lat_point_list = [52.35, 52.35, 52.65]
+        lon_point_list = [13.0, 13.4, 13.4]
+        area = Polygon(zip(lon_point_list, lat_point_list))
+        weather = weather_df_from_era5(
+            era5_netcdf_filename=self.era5_netcdf_file,
+            lib="windpowerlib",
+            area=area,
+            drop_coord_levels=True,
+        )
+        assert not isinstance(weather.index, pd.MultiIndex)

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -5,12 +5,12 @@ import pandas as pd
 import pytest
 import requests
 from shapely.geometry import GeometryCollection
+from shapely.geometry import Point
 from shapely.geometry import Polygon
 from shapely.geometry import shape
-from shapely.geometry import Point
 
-from feedinlib.era5 import weather_df_from_era5
 from feedinlib.era5 import extract_coordinates_from_era5
+from feedinlib.era5 import weather_df_from_era5
 
 
 class TestEra5MultiLocation:

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -67,7 +67,7 @@ class TestEra5MultiLocation:
         assert coords_round == [52.55, 13.35]
 
     def test_big_polygon(self):
-        lat_point_list = [52.1, 52.1, 52.65]
+        lat_point_list = [52.65, 52.65, 52.1]
         lon_point_list = [13.0, 13.4, 13.4]
         area = Polygon(zip(lon_point_list, lat_point_list))
         weather = weather_df_from_era5(
@@ -76,12 +76,12 @@ class TestEra5MultiLocation:
             area=area,
         )
         coords = weather.groupby(level=[1, 2]).mean().index
-        assert len(coords) == 2
+        assert len(coords) == 3
         coords_round = [round(p, 2) for c in coords for p in c]
-        assert coords_round == [52.3, 13.35, 52.55, 13.35]
+        assert coords_round == [52.3, 13.35, 52.55, 13.1, 52.55, 13.35]
 
     def test_empty_polygon(self):
-        lat_point_list = [53.1, 53.1, 53.65]
+        lat_point_list = [53.65, 53.65, 53.1]
         lon_point_list = [15.0, 15.4, 15.4]
         area = Polygon(zip(lon_point_list, lat_point_list))
         weather = weather_df_from_era5(
@@ -93,8 +93,8 @@ class TestEra5MultiLocation:
         assert isinstance(weather, pd.DataFrame)
 
     def test_small_polygon(self):
-        lat_point_list = [52.35, 52.35, 52.65]
-        lon_point_list = [13.0, 13.4, 13.4]
+        lat_point_list = [52.35, 52.35, 52.05]
+        lon_point_list = [13.0, 13.3, 13.3]
         area = Polygon(zip(lon_point_list, lat_point_list))
         weather = weather_df_from_era5(
             era5_netcdf_filename=self.era5_netcdf_file,
@@ -104,7 +104,7 @@ class TestEra5MultiLocation:
         coords = weather.groupby(level=[1, 2]).mean().index
         assert len(coords) == 1
         coords_round = [round(p, 2) for c in coords for p in c]
-        assert coords_round == [52.55, 13.35]
+        assert coords_round == [52.3, 13.1]
 
     def test_no_area(self):
         weather = weather_df_from_era5(

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,14 @@ envlist =
     clean,
     check,
     docs,
-    py36-cover,
-    py36-nocov,
     py37-cover,
-    py37-nocov,
     py38-cover,
-    py38-nocov,
     py39-cover,
-    py39-nocov,
     py3-nocov,
     report
 
 [gh-actions]
 python =
-    3.6: py36-cover
     3.7: py37-cover
     3.8: py38-cover
     3.9: py39-cover


### PR DESCRIPTION
Revise the functions `weather_df_from_era5()` and some connected functions:

* add function `extract_coordinates_from_era5(filename)` to get a 'GeoSeries` with all coordinates of the era5-netCDF-file (5aa50ea)
* If only one point was found within a polygon an error was raised -> fixed (c737488)
* If no point was found in some cases an error was raised -> fixed (ea93026e)
* A parameter was added to decide whether the levels with the coordinates were dropped or not (792883a)
* Add tests for the era5.py module
* Add coordinates as index name if levels are dropped (6e5c70b) e.g. print(df.index.name) -> (12.3, 53.2)
* If one Point is passed as a `shapely.geometry` the `nearest point` is used instead of `within` as it was before. 

~~The last point does not work, so I added a failing test. See code comment below.~~ -->fixed

One parameter in the function is called **area** but it can be a point, so I would like to rename it to `geometry` or `filter` or...