### PR TITLE
Removed return value and make target_file positional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ docs/temp/*
 
 # Mypy Cache
 .mypy_cache/
+
+tests/test_data/*
+examples/example_data/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,8 @@ include LICENSE
 include README.rst
 
 exclude docs/temp/*.rst
+exclude examples/example_data/*
+exclude tests/test_data/*
 
 recursive-include docs *.ipynb
 recursive-include examples *.csv

--- a/src/feedinlib/cds_request_tools.py
+++ b/src/feedinlib/cds_request_tools.py
@@ -1,8 +1,6 @@
 import logging
-import os
 from datetime import datetime
 from datetime import timedelta
-from tempfile import mkstemp
 
 import cdsapi
 import numpy as np

--- a/src/feedinlib/cds_request_tools.py
+++ b/src/feedinlib/cds_request_tools.py
@@ -83,11 +83,9 @@ def _get_cds_data(
     # Send the data request to the server
     result = cds_client.retrieve(dataset_name, request)
 
-    no_target_file_provided = target_file is None
     # Create a file in a secure way if a target filename was not provided
-    if no_target_file_provided is True:
-        fd, target_file = mkstemp(suffix=".nc")
-        os.close(fd)
+    if target_file.split(".")[-1] != "nc":
+        target_file = target_file + ".nc"
 
     logger.info(
         "Downloading request for {} variables to {}".format(

--- a/src/feedinlib/cds_request_tools.py
+++ b/src/feedinlib/cds_request_tools.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 def _get_cds_data(
     dataset_name="reanalysis-era5-single-levels",
     target_file=None,
-    chunks=None,
     cds_client=None,
     **cds_params,
 ):
@@ -32,12 +31,9 @@ def _get_cds_data(
         'Show API request', the short name is the string on the 6th line
         after 'c.retrieve('
     :param target_file: (str) name of the file to save downloaded locally
-    :param chunks: (dict)
     :param cds_client: handle to CDS client (if none is provided, then it is
         created)
     :param cds_params: (dict) parameter to pass to the CDS request
-
-    :return: CDS data in an xarray format
 
     """
 
@@ -101,18 +97,6 @@ def _get_cds_data(
 
     # Download the data in the target file
     result.download(target_file)
-
-    # Extract the data from the target file
-    answer = xr.open_dataset(target_file, chunks=chunks)
-
-    # Now that the data has been extracted the file path is removed if it was
-    # not provided. This will currently not work on windows if the dataset is
-    # too large as the file will be locked by the reading process.
-    if no_target_file_provided is True:
-        os.unlink(target_file)
-
-    # Here yield might be preferable in case of large datasets
-    return answer
 
 
 def _format_cds_request_datespan(start_date, end_date):
@@ -319,7 +303,6 @@ def get_cds_data_from_datespan_and_position(
         after 'c.retrieve('
     :param target_file: (str) name of the file in which downloading the data
         locally
-    :param chunks: (dict)
     :param cds_client: handle to CDS client (if none is provided, then it is
         created)
     :param cds_params: (dict) parameter to pass to the CDS request

--- a/src/feedinlib/cds_request_tools.py
+++ b/src/feedinlib/cds_request_tools.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 def _get_cds_data(
+    target_file,
     dataset_name="reanalysis-era5-single-levels",
-    target_file=None,
     cds_client=None,
     **cds_params,
 ):
@@ -340,4 +340,4 @@ def get_cds_data_from_datespan_and_position(
             )
     # in any other case no geographical subset is selected
 
-    return _get_cds_data(**cds_params)
+    _get_cds_data(**cds_params)

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -18,30 +18,41 @@ def get_era5_data_from_datespan_and_position(
     cds_client=None,
 ):
     """
-    Send request for era5 data to the Climate Data Store (CDS)
+    Download a netCDF file from the era5 weather data server for you position
+    and time range.
 
-    :param variable: (str or list of str) ERA5 variables to download. If you
-        want to download all variables necessary to use the pvlib, set
-        `variable` to 'pvlib'. If you want to download all variables necessary
-        to use the windpowerlib, set `variable` to 'windpowerlib'. To download
-        both variable sets for pvlib and windpowerlib, set `variable` to
-        'feedinlib'.
-    :param start_date: (str) start date of the date span in YYYY-MM-DD format
-    :param end_date: (str) end date of the date span in YYYY-MM-DD format
-    :param latitude: (number) latitude in the range [-90, 90] relative to the
-        equator, north corresponds to positive latitude.
-    :param longitude: (number) longitude in the range [-180, 180] relative to
-        Greenwich Meridian, east relative to the meridian corresponds to
-        positive longitude.
-    :param grid: (list of float) provide the latitude and longitude grid
-        resolutions in deg. It needs to be an integer fraction of 90 deg.
-    :param target_file: (str) name of the file in which to store downloaded
-        data locally
-    :param cds_client: handle to CDS client (if none is provided, then it is
-        created)
-    :return: CDS data in an xarray format
+    Parameters
+    ----------
+    start_date : str
+        Start date of the date span in YYYY-MM-DD format.
+    end_date : str
+        End date of the date span in YYYY-MM-DD format.
+    target_file : str
+        Name of the file in which to store downloaded data locally
+    variable : str
+        ERA5 variables to download. If you want to download all variables
+        necessary to use the pvlib, set `variable` to 'pvlib'. If you want to
+        download all variables necessary to use the windpowerlib, set
+        `variable` to 'windpowerlib'. To download both variable sets for pvlib
+        and windpowerlib, set `variable` to 'feedinlib'.
+    latitude : numeric
+        Latitude in the range [-90, 90] relative to the equator, north
+        corresponds to positive latitude.
+    longitude : numeric
+        Longitude in the range [-180, 180] relative to Greenwich Meridian, east
+        relative to the meridian corresponds to
+    grid : list or float
+        Provide the latitude and longitude grid resolutions in deg. It needs to
+        be an integer fraction of 90 deg.
+    cds_client : cdsapi.Client()
+        Handle to CDS client (if none is provided, then it is created)
+
+    Returns
+    -------
+    CDS data in an xarray format : xarray
 
     """
+
     if variable == "pvlib":
         variable = ["fdir", "ssrd", "2t", "10u", "10v"]
     elif variable == "windpowerlib":
@@ -115,9 +126,9 @@ def format_windpowerlib(ds):
     # the time stamp given by ERA5 for mean values (probably) corresponds to
     # the end of the valid time interval; the following sets the time stamp
     # to the middle of the valid time interval
-    df['time'] = df.time - pd.Timedelta(minutes=60)
+    df["time"] = df.time - pd.Timedelta(minutes=60)
 
-    df.set_index(['time', 'latitude', 'longitude'], inplace=True)
+    df.set_index(["time", "latitude", "longitude"], inplace=True)
     df.sort_index(inplace=True)
     df = df.tz_localize("UTC", level=0)
 
@@ -200,9 +211,9 @@ def format_pvlib(ds):
     # the time stamp given by ERA5 for mean values (probably) corresponds to
     # the end of the valid time interval; the following sets the time stamp
     # to the middle of the valid time interval
-    df['time'] = df.time - pd.Timedelta(minutes=30)
+    df["time"] = df.time - pd.Timedelta(minutes=30)
 
-    df.set_index(['time', 'latitude', 'longitude'], inplace=True)
+    df.set_index(["time", "latitude", "longitude"], inplace=True)
     df.sort_index(inplace=True)
     df = df.tz_localize("UTC", level=0)
 

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -58,7 +58,7 @@ def get_era5_data_from_datespan_and_position(
             "10u",
             "10v",
         ]
-    return get_cds_data_from_datespan_and_position(**locals())
+    get_cds_data_from_datespan_and_position(**locals())
 
 
 def format_windpowerlib(ds):

--- a/src/feedinlib/era5.py
+++ b/src/feedinlib/era5.py
@@ -10,12 +10,11 @@ from feedinlib.cds_request_tools import get_cds_data_from_datespan_and_position
 def get_era5_data_from_datespan_and_position(
     start_date,
     end_date,
+    target_file,
     variable="feedinlib",
     latitude=None,
     longitude=None,
     grid=None,
-    target_file=None,
-    chunks=None,
     cds_client=None,
 ):
     """
@@ -38,7 +37,6 @@ def get_era5_data_from_datespan_and_position(
         resolutions in deg. It needs to be an integer fraction of 90 deg.
     :param target_file: (str) name of the file in which to store downloaded
         data locally
-    :param chunks: (dict)
     :param cds_client: handle to CDS client (if none is provided, then it is
         created)
     :return: CDS data in an xarray format

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -1,6 +1,8 @@
-from feedinlib import era5
-import cdsapi
 from unittest import mock
+
+import cdsapi
+
+from feedinlib import era5
 
 
 def test_era5_download():

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -1,0 +1,12 @@
+from feedinlib import era5
+import cdsapi
+from unittest import mock
+
+
+def test_era5_download():
+    cdsapi.Client = mock.Mock()
+    instance_of_client = cdsapi.Client.return_value
+    instance_of_client.download.return_value = None
+    era5.get_era5_data_from_datespan_and_position(
+        "2019-01-19", "2019-01-20", "test_file.nc", "50.0", "12.0"
+    )


### PR DESCRIPTION
We should convince the users to download the file first and then use it instead of downloading it ever again. So the download function should not return the xarray. Even though the download may take hours so it does not make sense from this point of view.