### PR TITLE
Attempt to fix the deprecation issues...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "oedialect >= 0.0.6.dev0",
         "pvlib >= 0.7.0",
         "tables",
+        "open_FRED-cli",
         "windpowerlib > 0.2.0",
         "pandas >= 1.0",
         "xarray >= 0.12.0",

--- a/src/feedinlib/models/pvlib.py
+++ b/src/feedinlib/models/pvlib.py
@@ -112,6 +112,8 @@ class Pvlib(PhotovoltaicModelBase):
             "module_name",
             ["albedo", "surface_type"],
             "inverter_name",
+            "module_type",
+            "racking_model"
         ]
         # ToDo @Günni: is this necessary?
         if super().power_plant_requires is not None:
@@ -146,9 +148,9 @@ class Pvlib(PhotovoltaicModelBase):
         """
         if self.power_plant:
             return (
-                self.power_plant.module_parameters.Area
-                * self.power_plant.strings_per_inverter
-                * self.power_plant.modules_per_string
+                self.power_plant.arrays[0].module_parameters.Area
+                * self.power_plant.arrays[0].strings
+                * self.power_plant.arrays[0].modules_per_string
             )
         else:
             return None
@@ -170,18 +172,18 @@ class Pvlib(PhotovoltaicModelBase):
         if self.power_plant:
             if self.mode == "ac":
                 return min(
-                    self.power_plant.module_parameters.Impo
-                    * self.power_plant.module_parameters.Vmpo
-                    * self.power_plant.strings_per_inverter
-                    * self.power_plant.modules_per_string,
+                    self.power_plant.arrays[0].module_parameters.Impo
+                    * self.power_plant.arrays[0].module_parameters.Vmpo
+                    * self.power_plant.arrays[0].strings
+                    * self.power_plant.arrays[0].modules_per_string,
                     self.power_plant.inverter_parameters.Paco,
                 )
             elif self.mode == "dc":
                 return (
-                    self.power_plant.module_parameters.Impo
-                    * self.power_plant.module_parameters.Vmpo
-                    * self.power_plant.strings_per_inverter
-                    * self.power_plant.modules_per_string
+                    self.power_plant.arrays[0].module_parameters.Impo
+                    * self.power_plant.arrays[0].module_parameters.Vmpo
+                    * self.power_plant.arrays[0].strings
+                    * self.power_plant.arrays[0].modules_per_string
                 )
             else:
                 raise ValueError(
@@ -315,9 +317,9 @@ class Pvlib(PhotovoltaicModelBase):
         mc.run_model(weather=weather)
 
         if self.mode == "ac":
-            return mc.ac
+            return mc.results.ac
         elif self.mode == "dc":
-            return mc.dc.p_mp
+            return mc.results.dc.p_mp
         else:
             raise ValueError(
                 "{} is not a valid `mode`. `mode` must "

--- a/src/feedinlib/open_FRED.py
+++ b/src/feedinlib/open_FRED.py
@@ -301,7 +301,7 @@ class Weather:
     def location(self, point: Point):
         """ Get the measurement location closest to the given `point`.
         """
-        point = WKTE(point.to_wkt(), srid=4326)
+        point = WKTE(point.wkt, srid=4326)
         return (
             self.session.query(self.db["Location"])
             .order_by(self.db["Location"].point.distance_centroid(point))
@@ -311,7 +311,7 @@ class Weather:
     def within(self, region=None):
         """ Get all measurement locations within the given `region`.
         """
-        region = WKTE(region.to_wkt(), srid=4326)
+        region = WKTE(region.wkt, srid=4326)
         return (
             self.session.query(self.db["Location"])
             .filter(self.db["Location"].point.ST_Within(region))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ class Fixtures:
                 "temp_air": [10.0],
                 "dhi": [150.0],
                 "ghi": [300],
+                "dni": [610.11],
             },
             index=pd.date_range("1/1/1970 12:00", periods=1, tz="UTC"),
         )
@@ -61,6 +62,8 @@ class Fixtures:
             "azimuth": 180,
             "tilt": 30,
             "albedo": 0.2,
+            "module_type": "glass_glass",
+            "racking_model": "open_rack"
         }
 
     @pytest.fixture


### PR DESCRIPTION
... described by @uvchik  in #62.

* Since the new version of pvlib has made some changes to the data structures of the PV models, I have adapted the respective accesses to the new structure. 

* In addition, the two new parameters "module_type" and "racking_model" were added. 
These have to be set to the old state again on (#72) 

      - module_type = "glass_glass" 
      - racking_module = "open_rack" 

* The new version of pvlib also requires the direct normal irradiation (dni), which was calculated in the test file to reach the assert values again. For this purpose a zenith angle of about 75° was calculated. This seems a bit high for the first of January. Does anyone here have more detailed knowledge and can tell me what I need to change?

* furthermore I removed the shapely deprecation in open_FRED.py.

* Files touched: models/pvlib.py, open_FRED.py

*  Before I started my PR, the feedinlib already failed some tests on the Windpower model. This is still the case as I have not looked at the Windpowerlib.

* After this PR the pvlib Version has to be >= 0.9.0 (dependencies)