### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "oedialect >= 0.0.6.dev0",
         "pvlib >= 0.7.0",
         "tables",
+        "open_FRED-cli"
         "windpowerlib > 0.2.0",
         "pandas >= 1.0",
         "xarray >= 0.12.0",


### PR DESCRIPTION
open_FRED-cli is used but not named in setup.py as a requirement to be installed during installation of feedinlib:
https://github.com/oemof/feedinlib/blob/773cde0a2e5662b37d3be12d4d4ef6084907f5e6/src/feedinlib/open_FRED.py#L9

therefore I added open_FRED-cli to install_requires list